### PR TITLE
Implement config branch

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -7,23 +7,23 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"time"
 	"strconv"
+	"time"
 )
 
 type analyticsEvent struct {
-	Method string `json:"method"`
-	Path string `json:"path"`
-	TimeMilis int64 `json:"processingTimeInMiliseconds"`
-	Response string `json:"responseCode"`
-	Service string `json:"serviceName"`
-	Success bool `json:"success"`
+	Method    string `json:"method"`
+	Path      string `json:"path"`
+	TimeMilis int64  `json:"processingTimeInMiliseconds"`
+	Response  string `json:"responseCode"`
+	Service   string `json:"serviceName"`
+	Success   bool   `json:"success"`
 	Timestamp string `json:"timestamp"`
-	Username string `json:"username"`
+	Username  string `json:"username"`
 }
 
 var analyticsHost = fmt.Sprint(os.Getenv("ANALYTICS_URL"), "/saveEdr")
-var storeAnalytics = os.Getenv("STORE_ANALYTICS") == "1"
+var storeAnalytics = os.Getenv("STORE_ANALYTICS") == "true"
 
 func getEvent(path string, timeMillis int64, response string, success bool, timestamp time.Time) *analyticsEvent {
 	e := analyticsEvent{

--- a/main.go
+++ b/main.go
@@ -30,6 +30,33 @@ type idList struct {
 	IdList []int64 `json:"ids" binding:"required"`
 }
 
+func updateFlag(value string, statusOk bool, varName string) {
+	if statusOk {
+		_, err := strconv.ParseBool(value)
+		if err == nil {
+			os.Setenv(varName, value)
+		} else {
+			log.Println("Invalid config value for ", varName)
+		}
+	}
+}
+
+func config(c *gin.Context) {
+	analytics, analyticsOk := c.GetQuery("analytics")
+	faves, favesOk := c.GetQuery("faves")
+	login, loginOk := c.GetQuery("login")
+
+	updateFlag(analytics, analyticsOk, "STORE_ANALYTICS")
+	updateFlag(faves, favesOk, "CALL_FAVES")
+	updateFlag(login, loginOk, "CALL_LOGIN")
+
+	c.HTML(http.StatusOK, "index.tmpl.html", gin.H{
+		"analytics_status": os.Getenv("STORE_ANALYTICS"),
+		"faves_status":     os.Getenv("CALL_FAVES"),
+		"login_status":     os.Getenv("CALL_LOGIN"),
+	})
+}
+
 func search(c *gin.Context) {
 	start := time.Now()
 	// get search keywords
@@ -297,6 +324,7 @@ func main() {
 	router.GET("/getMovieById", getMovieByID)
 	router.GET("/search", search)
 	router.GET("/getMoviesByIds", getMoviesByIDs)
+	router.GET("/config", config)
 
 	router.Run(":" + port)
 }

--- a/templates/config.tmpl.html
+++ b/templates/config.tmpl.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Config Status</title>
+</head>
+<body>
+    <h3>Config Vars</h3>
+    <p>Analytics: {{.analytics_status}}}</p>
+    <p>Faves: {{.faves_status}}}</p>
+    <p>Login: {{.login_status}}}</p>
+</body>
+</html>


### PR DESCRIPTION
/config endpoint is used to set config vars to call other ms

**Format**
/config?analytics=true
/config?analytics=false&login=false&faves=false

- now we are using "true"/"false" string to set flags
- config vars can also be modified through heroku GUI but there maybe a conflict between what is displayed on the GUI and the real value during runtime. We can discuss later which way is better